### PR TITLE
fix shellcheck warnings

### DIFF
--- a/dmenu-bluetooth
+++ b/dmenu-bluetooth
@@ -58,7 +58,7 @@ scan_on() {
 # Toggles scanning state
 toggle_scan() {
     if scan_on; then
-        kill $(pgrep -F -f "bluetoothctl scan on")
+        kill "$(pgrep -F -f "bluetoothctl scan on")"
         bluetoothctl scan off
         show_menu
     else
@@ -125,11 +125,11 @@ device_connected() {
 
 # Toggles device connection
 toggle_connection() {
-    if device_connected $1; then
-        bluetoothctl disconnect $1
+    if device_connected "$1"; then
+        bluetoothctl disconnect "$1"
         # device_menu "$device"
     else
-        bluetoothctl connect $1
+        bluetoothctl connect "$1"
         # device_menu "$device"
     fi
 }
@@ -148,11 +148,11 @@ device_paired() {
 
 # Toggles device paired state
 toggle_paired() {
-    if device_paired $1; then
-        bluetoothctl remove $1
+    if device_paired "$1"; then
+        bluetoothctl remove "$1"
         device_menu "$device"
     else
-        bluetoothctl pair $1
+        bluetoothctl pair "$1"
         device_menu "$device"
     fi
 }
@@ -171,11 +171,11 @@ device_trusted() {
 
 # Toggles device connection
 toggle_trust() {
-    if device_trusted $1; then
-        bluetoothctl untrust $1
+    if device_trusted "$1"; then
+        bluetoothctl untrust "$1"
         device_menu "$device"
     else
-        bluetoothctl trust $1
+        bluetoothctl trust "$1"
         device_menu "$device"
     fi
 }
@@ -190,8 +190,8 @@ print_status() {
         counter=0
 
         for device in "${paired_devices[@]}"; do
-            if device_connected $device; then
-                device_alias=$(bluetoothctl info $device | grep -F "Alias" | cut -d ' ' -f 2-)
+            if device_connected "$device"; then
+                device_alias="$(bluetoothctl info "$device" | grep -F "Alias" | cut -d ' ' -f 2-)"
 
                 if [ $counter -gt 0 ]; then
                     printf ", %s" "$device_alias"
@@ -213,17 +213,17 @@ device_menu() {
     device=$1
 
     # Get device name and mac address
-    device_name=$(echo $device | cut -d ' ' -f 3-)
-    mac=$(echo $device | cut -d ' ' -f 2)
+    device_name="$(echo "$device" | cut -d ' ' -f 3-)"
+    mac="$(echo "$device" | cut -d ' ' -f 2)"
 
     # Build options
-    if device_connected $mac; then
+    if device_connected "$mac"; then
         connected="Connected: yes"
     else
         connected="Connected: no"
     fi
-    paired=$(device_paired $mac)
-    trusted=$(device_trusted $mac)
+    paired=$(device_paired "$mac")
+    trusted=$(device_trusted "$mac")
     options="$connected\n$paired\n$trusted\n$divider\n$goback\nExit"
 
     # Open dmenu menu, read chosen option
@@ -231,19 +231,19 @@ device_menu() {
 
     # Match chosen option to command
     case $chosen in
-        "" | $divider)
+        "" | "$divider")
             echo "No option chosen."
             ;;
-        $connected)
-            toggle_connection $mac
+        "$connected")
+            toggle_connection "$mac"
             ;;
-        $paired)
-            toggle_paired $mac
+        "$paired")
+            toggle_paired "$mac"
             ;;
-        $trusted)
-            toggle_trust $mac
+        "$trusted")
+            toggle_trust "$mac"
             ;;
-        $goback)
+        "$goback")
             show_menu
             ;;
     esac
@@ -276,19 +276,19 @@ show_menu() {
 
     # Match chosen option to command
     case $chosen in
-        "" | $divider)
+        "" | "$divider")
             echo "No option chosen."
             ;;
-        $power)
+        "$power")
             toggle_power
             ;;
-        $scan)
+        "$scan")
             toggle_scan
             ;;
-        $discoverable)
+        "$discoverable")
             toggle_discoverable
             ;;
-        $pairable)
+        "$pairable")
             toggle_pairable
             ;;
         *)


### PR DESCRIPTION
SC2086 (info): Double quote to prevent globbing and word splitting.
SC2254 (warning): Quote expansions in case patterns to match literally rather than as a glob.

Honestly in this case these aren't big issues, but it's good practice to follow them.
