### PR TITLE
fix being unable to turn off scanning for devices

### DIFF
--- a/dmenu-bluetooth
+++ b/dmenu-bluetooth
@@ -58,7 +58,7 @@ scan_on() {
 # Toggles scanning state
 toggle_scan() {
     if scan_on; then
-        kill "$(pgrep -F -f "bluetoothctl scan on")"
+        kill $(pgrep -f "bluetoothctl scan on")
         bluetoothctl scan off
         show_menu
     else


### PR DESCRIPTION
`pgrep -F` expects a file, so that command doesn't work at all so the flag should be removed. The quotes should also be removed to enable word splitting in case there are more of those processes.